### PR TITLE
bugfix/fmp-limits

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -2,13 +2,12 @@ name: Django CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
@@ -16,19 +15,19 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install Dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-    - name: Set Environment
-      run: |
-        echo "SECRET_KEY=$(openssl rand -base64 32)" >> $GITHUB_ENV
-        echo "DEBUG=true" >> $GITHUB_ENV
-    - name: Run Tests
-      run: |
-        python -Wa stockhelper/manage.py test stockhelper/
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Set Environment
+        run: |
+          echo "SECRET_KEY=$(openssl rand -base64 32)" >> $GITHUB_ENV
+          echo "DEBUG=true" >> $GITHUB_ENV
+      - name: Run Tests
+        run: |
+          python -Wa stockhelper/manage.py test stockhelper/ -v 2

--- a/stockhelper/stockapp/api.py
+++ b/stockhelper/stockapp/api.py
@@ -4,7 +4,7 @@ from time import sleep
 # Data provided by Financial Modeling Prep: https://financialmodelingprep.com/developer/docs/
 API_KEY = "174c8948d0e48bad0418e1fe49d72e15"
 FMP = "https://financialmodelingprep.com"
-RETRY_LIMIT = 3
+RETRY_LIMIT = 5
 
 
 def get_request(req_str, retry=0):

--- a/stockhelper/stockapp/api.py
+++ b/stockhelper/stockapp/api.py
@@ -1,8 +1,28 @@
 import requests
+from time import sleep
 
 # Data provided by Financial Modeling Prep: https://financialmodelingprep.com/developer/docs/
 API_KEY = "174c8948d0e48bad0418e1fe49d72e15"
 FMP = "https://financialmodelingprep.com"
+
+
+def get_request(req_str):
+    req = requests.get(req_str)
+    json = req.json()
+
+    # FMP imposes a rate limit, so check to see if an error occurred
+    if isinstance(json, dict) and "X-Rate-Limit-Retry-After-Milliseconds" in json:
+        # Use X-Rate-Limit-Retry-After-Seconds and X-Rate-Limit-Retry-After-Milliseconds to
+        # determine how long to sleep for before retrying
+        secs = json.get("X-Rate-Limit-Retry-After-Seconds", 0)
+        msecs = json["X-Rate-Limit-Retry-After-Milliseconds"]
+        sleep(secs + msecs / 1000)
+
+        req = requests.get(req_str)
+        json = req.json()
+
+    return json
+
 
 def get_stocks(form_data):
     # Collect the form data
@@ -21,17 +41,16 @@ def get_stocks(form_data):
         search_str += f"&sector={sector}"
 
     if exchange == "etf":
-        search_str += f"&isEtf=true" # works better than exchange=etf
+        search_str += f"&isEtf=true"  # works better than exchange=etf
     elif exchange != "Any":
         search_str += f"&exchange={exchange}"
 
-    req = requests.get(search_str)
-    return req.json()
+    return get_request(search_str)
+
 
 def get_company_profile(ticker):
-    req = requests.get(f"{FMP}/api/v3/profile/{ticker}?apikey={API_KEY}")
-    return req.json()
+    return get_request(f"{FMP}/api/v3/profile/{ticker}?apikey={API_KEY}")
+
 
 def get_stock_history(ticker):
-    req = requests.get(f"{FMP}/api/v3/historical-price-full/{ticker}?apikey={API_KEY}&serietype=line")
-    return req.json()
+    return get_request(f"{FMP}/api/v3/historical-price-full/{ticker}?apikey={API_KEY}&serietype=line")

--- a/stockhelper/stockapp/static/stockapp/js/portfolio.js
+++ b/stockhelper/stockapp/static/stockapp/js/portfolio.js
@@ -3,6 +3,7 @@ const roiAlert = document.querySelector(".roi-alert");
 const portfolio = document.querySelector(".portfolio");
 const roi = document.querySelector(".roi");
 const portfolioStatus = document.querySelector(".portfolio-status");
+const balance = document.querySelector(".balance");
 const netWorthDom = document.querySelector(".net-worth");
 const netWorthSpinner = document.querySelector(".net-worth-spinner");
 
@@ -17,66 +18,84 @@ const toMoney = (num) =>
         maximumFractionDigits: 2,
     })}`;
 
+// Parse a money string into a float
+const toNum = (str) => parseFloat(str.replace(/[$,]/g, ""));
+
 // Asychronously update the price and change of each stock, then update the net worth
 const getPriceAndChange = async () => {
-    try {
-        const req = await fetch(
-            `${window.location.origin}/stockapp/api/prices`
-        );
-        const resp = await req.json();
-        const { netWorth, prices } = resp;
+    // Add the current balance with the value of each stock to calculate the user's net worth
+    let netWorth = toNum(balance.textContent);
 
-        // Replace the spinner with the actual value
-        netWorthSpinner.remove();
-        netWorthDom.textContent = toMoney(netWorth);
+    for (const row of tableRows) {
+        const stockTicker = row.querySelector(".stock-ticker");
 
-        const startingBalance = 10000;
-        const netWorthChange = netWorth - startingBalance;
+        try {
+            const req = await fetch(
+                `${window.location.origin}/stockapp/api/price/${stockTicker.textContent}`
+            );
+            const resp = await req.json();
 
-        if (netWorthChange > 0) {
-            // Give the user feedback on how well their investment is going
-            portfolioStatus.textContent =
-                "Right now, you're making a profit. Keep up the good work!";
-            roiAlert.classList.remove("alert-info");
-            roiAlert.classList.add("alert-success");
-
-            // Show how much the net worth has changed (25b2 for up arrow and 25bc for down arrow)
-            netWorthDom.classList.add("text-success");
-            netWorthDom.innerHTML += ` &#x25b2; ${toMoney(netWorthChange)}`;
-        } else if (netWorthChange < 0) {
-            portfolioStatus.textContent =
-                "Right now, you have a net loss. Consider selling stocks " +
-                "that are falling or buying stocks that are on the rise.";
-            roiAlert.classList.remove("alert-info");
-            roiAlert.classList.add("alert-danger");
-
-            netWorthDom.classList.add("text-danger");
-            netWorthDom.innerHTML += ` &#x25bc; ${toMoney(-netWorthChange)}`;
-        }
-
-        tableRows.forEach((row, r) => {
-            // Remove the spinners and display the price and change for each row
+            // Remove the spinners
             const stockPrice = row.querySelector(".stock-price");
             const priceSpinner = row.querySelector(".price-spinner");
-            priceSpinner.remove();
-            stockPrice.textContent = `$${prices[r].price}`;
-
             const stockChange = row.querySelector(".stock-change");
             const changeSpinner = row.querySelector(".change-spinner");
+            priceSpinner.remove();
             changeSpinner.remove();
-            const change = prices[r].change;
 
-            // Make the change text green or red depending on its sign
-            if (change < 0) {
-                stockChange.innerHTML = `&#x25bc; ${-change}`;
+            // Show an error if the request failed
+            if (resp.error !== undefined) {
+                stockPrice.textContent = "Error";
+                stockPrice.classList.add("text-danger");
+                stockChange.textContent = resp.error;
                 stockChange.classList.add("text-danger");
             } else {
-                stockChange.innerHTML = `&#x25b2; ${change}`;
-                stockChange.classList.add("text-success");
+                const { price, change, shares } = resp;
+                netWorth += shares * price;
+
+                // Display the price and change for each row
+                stockPrice.textContent = `$${price}`;
+
+                // Make the change text green or red depending on its sign
+                if (change < 0) {
+                    stockChange.innerHTML = `&#x25bc; ${-change}`;
+                    stockChange.classList.add("text-danger");
+                } else {
+                    stockChange.innerHTML = `&#x25b2; ${change}`;
+                    stockChange.classList.add("text-success");
+                }
             }
-        });
-    } catch (error) {
-        console.error(`Error: ${error}`);
+        } catch (error) {
+            console.error(`Error: ${error}`);
+        }
+    }
+
+    // Replace the spinner with the actual value
+    netWorthSpinner.remove();
+    netWorthDom.textContent = toMoney(netWorth);
+
+    const startingBalance = 10000;
+    const netWorthChange = netWorth - startingBalance;
+
+    if (netWorthChange > 0) {
+        // Give the user feedback on how well their investment is going
+        portfolioStatus.textContent =
+            "Right now, you're making a profit. Keep up the good work!";
+        roiAlert.classList.remove("alert-info");
+        roiAlert.classList.add("alert-success");
+
+        // Show how much the net worth has changed (25b2 for up arrow and 25bc for down arrow)
+        netWorthDom.classList.add("text-success");
+        netWorthDom.innerHTML += ` &#x25b2; ${toMoney(netWorthChange)}`;
+    } else if (netWorthChange < 0) {
+        portfolioStatus.textContent =
+            "Right now, you have a net loss. Consider selling stocks " +
+            "that are falling or buying stocks that are on the rise.";
+        roiAlert.classList.remove("alert-info");
+        roiAlert.classList.add("alert-danger");
+
+        netWorthDom.classList.add("text-danger");
+        netWorthDom.innerHTML += ` &#x25bc; ${toMoney(-netWorthChange)}`;
     }
 };
 

--- a/stockhelper/stockapp/templates/stockapp/detail.html
+++ b/stockhelper/stockapp/templates/stockapp/detail.html
@@ -3,7 +3,7 @@
 {% load custom_tags %}
 
 {% block title %}
-{% if profile is None %}
+{% if profile is None or 'companyName' not in profile %}
 Details - ???
 {% else %}
 Details - {{ profile.companyName }}
@@ -24,6 +24,12 @@ Details - {{ profile.companyName }}
 {% block content %}
 {% if profile is None %}
 <p class="text-danger my-3">Error: Unknown stock ticker: {{ history }}</p>
+
+{% elif 'companyName' not in profile or 'Error Message' in history %}
+<!-- The FMP API gave an error response -->
+<p class="text-danger my-3">The server reported an error:</p>
+<p>Profile: {{ profile }}</p>
+<p>History: {{ history }}</p>
 
 {% else %}
 <div class="main-info-container mt-3">

--- a/stockhelper/stockapp/urls.py
+++ b/stockhelper/stockapp/urls.py
@@ -10,5 +10,5 @@ urlpatterns = [
     path("flashcards", views.FlashCardsView.as_view(), name="flashcards"),
     path("portfolio", views.get_portfolio, name="portfolio"),
     path("session/balance", views.SessionBalanceView.as_view(), name="balance"),
-    path("api/prices", views.PricesView.as_view(), name="prices")
+    path("api/price/<ticker>", views.PriceView.as_view(), name="price")
 ]

--- a/stockhelper/stockapp/views.py
+++ b/stockhelper/stockapp/views.py
@@ -36,7 +36,11 @@ def get_stocks(request):
         if form.is_valid():
             # Query the dataset
             stock_data = api.get_stocks(form.cleaned_data)
-            request.session["results"] = stock_data
+
+            # If stock_data isn't a list (due to an API error), treat it like there are no results
+            if isinstance(stock_data, list):
+                request.session["results"] = stock_data
+
             # Return an HttpResponseRedirect to prevent the data from being posted twice
             return HttpResponseRedirect(reverse("stockapp:screener"))
 

--- a/stockhelper/stockhelper/settings.py
+++ b/stockhelper/stockhelper/settings.py
@@ -161,4 +161,5 @@ LOGGING = {
 
 # Activate Django-on-Heroku (breaks if testing)
 if sys.argv[1:2] != ["test"]:
-    django_on_heroku.settings(locals(), logging=False)  # logging=False prevents LOGGING from being overwritten
+    # logging=False prevents LOGGING from being overwritten
+    django_on_heroku.settings(locals(), logging=False)


### PR DESCRIPTION
Since FMP imposed new API restrictions for the free plan, the following changes were made to honor those limits:

- If an error message appears when making a request, sleep for `X-Rate-Limit-Retry-After-Seconds` seconds and `X-Rate-Limit-Retry-After-Milliseconds` milliseconds and retry the request up to 5 times
- Error messages appear on the detail and portfolio views
- The prices view was adjusted so it only fetches information for one stock ticker at a time
- As such, the portfolio view now loads each stock one at a time before and the net worth is calculated on the client-side instead of the server-side
- New tests for the price view
- _Bonus_: more verbose output during CI/CD testing