### PR TITLE
Full Historical Prices Removed From Free Plan

### DIFF
--- a/stockhelper/stockapp/api.py
+++ b/stockhelper/stockapp/api.py
@@ -65,4 +65,4 @@ def get_company_profile(ticker):
 
 
 def get_stock_history(ticker):
-    return get_request(f"{FMP}/api/v3/historical-price-full/{ticker}?apikey={API_KEY}&serietype=line")
+    return get_request(f"{FMP}/api/v3/technical_indicator/daily/{ticker}?apikey={API_KEY}")

--- a/stockhelper/stockapp/views.py
+++ b/stockhelper/stockapp/views.py
@@ -171,10 +171,9 @@ def get_stock_details(request, ticker):
     else:
         profile = raw_profile
 
-    # history should be a dict with a historical key, display an error if that's not the case
-    if isinstance(raw_history, dict) and "historical" in raw_history:
-        history = raw_history["historical"]
-    elif isinstance(raw_history, dict) and "Error Message" in raw_history:
+    # history should be a list, display an error if that's not the case
+    if isinstance(raw_history, list) or (
+            isinstance(raw_history, dict) and "Error Message" in raw_history):
         history = raw_history
     else:
         history = ticker

--- a/stockhelper/stockapp/views.py
+++ b/stockhelper/stockapp/views.py
@@ -36,6 +36,7 @@ def get_stocks(request):
         if form.is_valid():
             # Query the dataset
             stock_data = api.get_stocks(form.cleaned_data)
+            print(f"{stock_data=}")
 
             # If stock_data isn't a list (due to an API error), treat it like there are no results
             if isinstance(stock_data, list):
@@ -146,6 +147,8 @@ def get_stock_details(request, ticker):
     raw_profile = api.get_company_profile(ticker)  # returns a list of dicts
     # returns a dict with symbol and historical list
     raw_history = api.get_stock_history(ticker)
+    print(f"{raw_profile=}")
+    print(f"{raw_history=}")
 
     terms = {
         "beta": Card.objects.get(word="Beta"),
@@ -240,6 +243,7 @@ class PriceView(LoginRequiredMixin, generic.base.TemplateView):
                 user=request.user, stock=upper_ticker)
             stock = portfolio.stock
             raw_profile = api.get_company_profile(upper_ticker)
+            print(f"{raw_profile=}")
 
             # profile should be an array with one element, display an error if that's not the case
             if not raw_profile:

--- a/stockhelper/stockapp/views.py
+++ b/stockhelper/stockapp/views.py
@@ -171,8 +171,8 @@ def get_stock_details(request, ticker):
     else:
         profile = raw_profile
 
-    # history should be a list, display an error if that's not the case
-    if isinstance(raw_history, list) or (
+    # history should be a list with at least one element, display an error if that's not the case
+    if (isinstance(raw_history, list) and raw_history) or (
             isinstance(raw_history, dict) and "Error Message" in raw_history):
         history = raw_history
     else:


### PR DESCRIPTION
Coincidentally, when I was trying to debug the initial CI failures that occur with each dependency update, I ran across a different issue. The historical stock price API used in the Details View now fails with the following error:

```json
{
  "Error Message": "Special Endpoint : this endpoint is not available under your current subscription please visit our subscription page to upgrade your plan at https://financialmodelingprep.com/developer/docs/pricing"
}
```

I double-checked in [FMP's docs](https://site.financialmodelingprep.com/developer/docs#Stock-Historical-Price) and I was consistently getting the same error on all the Historical Daily Prices endpoints.

Previously, FMP introduced rate-limiting without notice, which forced us to accommodate the app to retry failed requests. And now, unfortunately, they're stripping away the ability to view stock prices over the past year under the free plan (despite it claiming to offer [annual data](https://site.financialmodelingprep.com/developer/docs/pricing)).

Luckily, FMP offers another endpoint under the Free Plan: [Daily Indicators](https://site.financialmodelingprep.com/developer/docs#Daily-Indicators), which still retains the historical price information present in the historical-price-full endpoint. Also, there's no more historical key in either endpoint. It's just a list now. Let's hope this stays free! 🤞🏽