### PR TITLE
Wip/django on fly

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,3 +31,4 @@ jobs:
 
       - name: Deploy to Fly.io
         run: flyctl deploy --remote-only
+        timeout-minutes: 10 # default: 6 hours

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ chardet==5.0.0
 charset-normalizer==2.1.1
 dj-database-url==1.0.0
 Django==4.1.2
-django-on-heroku==1.1.2
 gunicorn==20.1.0
 idna==3.4
 psycopg2-binary==2.9.4


### PR DESCRIPTION
This PR addresses two things:

- The last `fly deploy` job timed out after 6 hours, so I reduced the timeout to 10 minutes since the job shouldn't hang for that long.
- Since `django-heroku` is [deprecated](https://github.com/heroku/django-heroku/issues/56), the recommendation is to inline the prod configurations in `settings.py` ourselves. Since most of this was already done, I added the rest of the config needed (aka the static files settings), so we can remove the `django-on-heroku` dependency.