### PR TITLE
Allow localhost & secure cookies

### DIFF
--- a/stockhelper/stockhelper/settings.py
+++ b/stockhelper/stockhelper/settings.py
@@ -39,10 +39,10 @@ if "SECRET_KEY" in os.environ:
 # Set DEBUG to false by default unless explicitly stated
 DEBUG = os.environ.get("DEBUG", "false").lower() == "true"
 
-ALLOWED_HOSTS = ["how-to-stock-3.fly.dev"]
-
-# Trust Fly.io when deployed
-CSRF_TRUSTED_ORIGINS = ['https://how-to-stock-3.fly.dev']
+# Trust localhost during development and Fly.io when deployed
+ALLOWED_HOSTS = [".localhost", "127.0.0.1", "[::1]", "how-to-stock-3.fly.dev"]
+SESSION_COOKIE_SAMESITE = "Strict"
+SESSION_COOKIE_SECURE = True
 
 
 # Application definition


### PR DESCRIPTION
I might've confused CSRF_TRUSTED_ORIGINS with ALLOWED_HOSTS. I don't think CSRF_TRUSTED_ORIGINS is needed since we're not sending POST requests to external sites. This PR also serves to secure the session cookie using the industry's best practices: HttpOnly, Secure, and SameSite=Secure. Django's docs even [recommend](https://docs.djangoproject.com/en/4.1/ref/settings/#session-cookie-secure) setting SESSION_COOKIE_SECURE to True.