### PR TITLE
Remove SECRET_KEY comment

### DIFF
--- a/stockhelper/stockhelper/settings.py
+++ b/stockhelper/stockhelper/settings.py
@@ -31,7 +31,6 @@ if os.path.isfile(dotenv_file) and not IS_PROD:
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-# SECRET_KEY = 'e*z=5=4f+f4oeqx1mnm(t(vf%6j1q)@v#%zs+)0k4!nq*r$or-'
 if "SECRET_KEY" in os.environ:
     SECRET_KEY = os.environ["SECRET_KEY"]
 


### PR DESCRIPTION
GitGuardian doesn't like seeing the SECRET_KEY in code, even as a comment. Don't worry, the key isn't valid and I've been storing it as an environment variable.